### PR TITLE
signer: allow spaces when matching org unit in cert subject

### DIFF
--- a/isign/signer.py
+++ b/isign/signer.py
@@ -164,7 +164,7 @@ class Signer(object):
             '-noout'
         ]
         certificate_info = openssl_command(cmd)
-        subject_with_ou_match = re.compile(b'\s+Subject:.*OU=(\w+)')
+        subject_with_ou_match = re.compile(b'\s+Subject:.*OU\s*=\s*(\w+)')
         for line in certificate_info.splitlines():
             match = subject_with_ou_match.match(line)
             if match is not None:


### PR DESCRIPTION
I was seeing that the output of:

    openssl x509 -text -in certificate.pem

shows a Subject: which has spaces around the equals sign for the
organisational unit.

This updates the regex to allow for that (otherwise I get an
isign.exceptions.ImproperCredentials after failing to match any
organisational unit).