### PR TITLE
Sign ios 11

### DIFF
--- a/isign/bundle.py
+++ b/isign/bundle.py
@@ -264,3 +264,7 @@ class App(Bundle):
 
         # actually resign this bundle now
         super(App, self).resign(deep, signer)
+
+        # The entitlements are only needed temporarily while signing so we
+        # don't want to leave the file in the Payload/archive...
+        os.remove(self.entitlements_path);

--- a/isign/code_resources.py
+++ b/isign/code_resources.py
@@ -134,6 +134,12 @@ class ResourceBuilder(object):
                                                                     filename)
                 # log.debug(rule_debug_fmt.format(rule, path, relative_path))
 
+                # There's no rule for the Entitlements.plist file which we
+                # generate temporarily so we just ommit the file as a special
+                # case...
+                if relative_path == 'Entitlements.plist':
+                    continue
+
                 if rule.is_exclusion():
                     continue
 

--- a/isign/code_resources.py
+++ b/isign/code_resources.py
@@ -110,7 +110,7 @@ class ResourceBuilder(object):
                 if rule.flags and rule.is_exclusion():
                     best_rule = rule
                     break
-                elif rule.weight > best_rule.weight:
+                elif rule.weight >= best_rule.weight:
                     best_rule = rule
         return best_rule
 


### PR DESCRIPTION
These changes enabled me to re-sign a simple package that I could then install on an iOS 11 device

Fixes #14 for me, at least for a simple package that was initially signed on OSX (i.e. re-sigining - not signing from scratch)